### PR TITLE
Update 03-create-cluster.md

### DIFF
--- a/docs/03-create-cluster.md
+++ b/docs/03-create-cluster.md
@@ -1,5 +1,11 @@
 # Create A Kubernetes Cluster on Google Cloud
 
+Make sure the "container" service is enabled for your account:
+```
+gcloud services enable container
+```
+Otherwise you get an error like `Consumer XXXXXXXXX should enable service:container.googleapis.com before generating a service account.`
+
 Create the Kubernetes Cluster:
 ```
 gcloud container clusters create kubernetes-the-easy-way


### PR DESCRIPTION
When running the command `gcloud container clusters create my-cluster-name` I get an error: 

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Failed precondition when calling the ServiceConsumerManager: tenantmanager::XXX: Consumer XXX should enable service:container.googleapis.com before generating a service account.
com.google.api.tenant.error.TenantManagerException: Consumer XXX should enable service:container.googleapis.com before generating a service account.
```

I think this fixes it.